### PR TITLE
fixed bug where default was altered when render was initiated

### DIFF
--- a/playback_element.ts
+++ b/playback_element.ts
@@ -23,8 +23,8 @@ export class PlaybackElement extends MarkdownRenderChild {
 
   onload() {
     const { userOptions, source } = this.parseOptionsAndSource();
-    const options = { ...DEFAULT_OPTIONS, ...userOptions }
-    const renderResp = renderAbc(this.el, source, options)    
+    const options = { ...DEFAULT_OPTIONS, ...userOptions };
+    const renderResp = renderAbc(this.el, source, options);
     this.enableAudioPlayback(renderResp[0]);
   }
 

--- a/playback_element.ts
+++ b/playback_element.ts
@@ -23,7 +23,8 @@ export class PlaybackElement extends MarkdownRenderChild {
 
   onload() {
     const { userOptions, source } = this.parseOptionsAndSource();
-    const renderResp = renderAbc(this.el, source, Object.assign(DEFAULT_OPTIONS, userOptions));
+    const options = { ...DEFAULT_OPTIONS, ...userOptions }
+    const renderResp = renderAbc(this.el, source, options)    
     this.enableAudioPlayback(renderResp[0]);
   }
 


### PR DESCRIPTION
fixes #32 and #42 and possibly others as well

`Object.assign(X, Y)` <= X is updated with Y's values